### PR TITLE
Set LOGROTATE_COMPRESSED_FILENAME environment when compressing file.

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -524,6 +524,7 @@ static int removeLogFile(char *name, struct logInfo *log)
 static int compressLogFile(char *name, struct logInfo *log, struct stat *sb)
 {
     char *compressedName;
+    char *envInFilename;
     const char **fullCommand;
     struct utimbuf utim;
     int inFile;
@@ -598,6 +599,9 @@ static int compressLogFile(char *name, struct logInfo *log, struct stat *sb)
 		DOEXIT(1);
 	}
 
+	envInFilename = alloca(strlen("LOGROTATE_COMPRESSED_FILENAME=") + strlen(name) + 2);
+	sprintf(envInFilename, "LOGROTATE_COMPRESSED_FILENAME=%s", name);
+	putenv(envInFilename);
 	execvp(fullCommand[0], (void *) fullCommand);
 	DOEXIT(1);
     }

--- a/test/compress
+++ b/test/compress
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 echo "gzip $*" > compress-args
+env > compress-env
 gzip $*

--- a/test/test
+++ b/test/test
@@ -61,7 +61,7 @@ fi
 
 
 cleanup() {
-    rm -f test*.log* anothertest*.log* state test-config. scriptout mail-out compress-args different*.log*
+    rm -f test*.log* anothertest*.log* state test-config. scriptout mail-out compress-* different*.log*
     rm -f $(ls | egrep '^test-config.[0-9]+$')
 
     [ -n "$1" ] && echo "Running test $1"
@@ -573,6 +573,11 @@ test.log.1.gz 1 zero
 EOF
 
 (echo "gzip -f -9") | diff -u - compress-args
+egrep -q '^LOGROTATE_COMPRESSED_FILENAME=.+/test/test.log.1$' compress-env
+if [ $? != 0 ]; then
+      echo "LOGROTATE_COMPRESSED_FILENAME environment variable not found."
+      cat compress-env++      exit 3
+fi
 
 cleanup 19
 


### PR DESCRIPTION
The compress program doesn't know the name of the file being compressed. We're
using a custom wrapper for compressing files which needs to know the name of
the compressed file.

We could pass the name of the compressed file in the
logrotate configuration itself using compressoptions:

  /var/log/foo.log {

```
compresscmd my_wrapper
compressoptions /var/log/foo.log
```

  }

However this doesn't work with wildcard filename:

  /var/log/*log {

```
compresscmd my_wrapper
compressoptions ???
```

  }

given that wildcard filenames are only known when the compress command is
called.
